### PR TITLE
Moved set up of pagination total rows in header to ApiService

### DIFF
--- a/Service/ApiService.php
+++ b/Service/ApiService.php
@@ -44,5 +44,17 @@ class ApiService implements Filter, Pagination, Sort
         $this->applyFilteredFieldsToQueryBuilder($queryBuilder);
         $this->applySortedFieldsToQueryBuilder($queryBuilder);
         $this->applyPaginationToQueryBuilder($queryBuilder);
+
+        $this->addHeaderInformation();
+    }
+
+    /**
+     * Adds all information in response header
+     */
+    public function addHeaderInformation()
+    {
+        if ($this->getPaginationTotal() !== null) {
+            $this->headerInformation->add('pagination-total', $this->getPaginationTotal());
+        }
     }
 }

--- a/Service/PaginationTrait.php
+++ b/Service/PaginationTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Shopping\ApiTKUrlBundle\Service;
 
 use Doctrine\ORM\QueryBuilder;
-use Shopping\ApiHelperBundle\Service\HeaderInformation;
 use Shopping\ApiTKUrlBundle\Exception\PaginationException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Shopping\ApiTKUrlBundle\Annotation as Api;
@@ -22,11 +21,6 @@ trait PaginationTrait
      * @var RequestStack
      */
     private $requestStack;
-
-    /**
-     * @var HeaderInformation
-     */
-    private $headerInformation;
 
     /**
      * @var Api\Pagination
@@ -146,8 +140,6 @@ trait PaginationTrait
     public function setPaginationTotal(int $paginationTotal): void
     {
         $this->paginationTotal = $paginationTotal;
-
-        $this->headerInformation->add('pagination-total', $this->paginationTotal);
     }
 
     /**


### PR DESCRIPTION
We shouldn't have a dependency to another bundle (ApiTKHeaderBundle) so deep in a trait. It will be harder for someone who doesn't want to send that info in response header to overwrite. Let keep these dependencies in ApiService.