### PR TITLE
Improve readme for better visibility of extending existing repos by `ApiToolkitRepository`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ amount of entries, so the client can adjust his pagination buttons.
 
 ### Accessing client input
 #### Autoloading array through param converter
-If you have a default case, just extend ApiToolkitRepository in your own repo. You can do this 
+If you have a default case, just **extend** ApiToolkitRepository in your own repo. You can do this 
 automatically so you even don't have to create a repository for your entity. Just add this 
 line to your `doctrine.yaml`:
 ```


### PR DESCRIPTION
One of my colleges used this bundle but didn't extend his repository by the `ApiToolkitRepository` but instead implemented the `findByRequest` method himself.

I hope with bolding the word "extend" it is harder to overlook when reading the docu.