### PR TITLE
Feature/apply pagination before sorting

### DIFF
--- a/Service/ApiService.php
+++ b/Service/ApiService.php
@@ -42,7 +42,8 @@ class ApiService implements Filter, Pagination, Sort
     public function applyToQueryBuilder(QueryBuilder $queryBuilder): void
     {
         $this->applyFilteredFieldsToQueryBuilder($queryBuilder);
-        $this->applyPaginationToQueryBuilder($queryBuilder);
+        $this->applyPaginationTotal($queryBuilder);
         $this->applySortedFieldsToQueryBuilder($queryBuilder);
+        $this->applyPaginationToQueryBuilder($queryBuilder);
     }
 }

--- a/Service/ApiService.php
+++ b/Service/ApiService.php
@@ -42,7 +42,7 @@ class ApiService implements Filter, Pagination, Sort
     public function applyToQueryBuilder(QueryBuilder $queryBuilder): void
     {
         $this->applyFilteredFieldsToQueryBuilder($queryBuilder);
-        $this->applySortedFieldsToQueryBuilder($queryBuilder);
         $this->applyPaginationToQueryBuilder($queryBuilder);
+        $this->applySortedFieldsToQueryBuilder($queryBuilder);
     }
 }

--- a/Service/PaginationTrait.php
+++ b/Service/PaginationTrait.php
@@ -63,9 +63,23 @@ trait PaginationTrait
      *
      * @param QueryBuilder $queryBuilder
      * @throws PaginationException
-     * @throws \Doctrine\ORM\NonUniqueResultException
      */
     public function applyPaginationToQueryBuilder(QueryBuilder $queryBuilder): void
+    {
+        if ($this->pagination !== null) {
+            $queryBuilder->distinct();
+
+            $queryBuilder->setMaxResults($this->getPaginationLimit());
+            $queryBuilder->setFirstResult($this->getPaginationOffset());
+        }
+    }
+
+    /**
+     * Calculates pagination total.
+     *
+     * @param QueryBuilder $queryBuilder
+     */
+    public function applyPaginationTotal(QueryBuilder $queryBuilder): void
     {
         if ($this->pagination !== null) {
             $queryBuilder->distinct();
@@ -76,9 +90,6 @@ trait PaginationTrait
             try {
                 $this->setPaginationTotal((int)$totalQueryBuilder->getQuery()->getSingleScalarResult());
             } catch (\Exception $e) {} //F.e. for TableNotFoundExceptions
-
-            $queryBuilder->setMaxResults($this->getPaginationLimit());
-            $queryBuilder->setFirstResult($this->getPaginationOffset());
         }
     }
 


### PR DESCRIPTION
Just moved applying of "COUNT query" before applying sorting because it is not relevant for counting rows. Not sure if mysql optimize that and ignore ORDER BY when there is only COUNT in select but just to be sure here (also we don't know if it will be used mysql or something other there). 