### PR TITLE
Fix using ApiToolkitRepository as the default_repository_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ amount of entries, so the client can adjust his pagination buttons.
 #### Autoloading array through param converter
 You can automatically get the entity result array of all your filters in the correct order and pagination subset easily injected into your action.
 
-First set your default repository in your `doctrine.yaml` to our `ApiToolkitRepository`:
+First set your default repository in your `doctrine.yaml` to our `ApiToolkitDefaultRepository`:
 ```
 doctrine:
     orm:
-        default_repository_class: Shopping\ApiTKUrlBundle\Repository\ApiToolkitRepository
+        default_repository_class: Shopping\ApiTKUrlBundle\Repository\ApiToolkitDefaultRepository
 ```
-For all your custom repositories, extend them from the `ApiToolkitRepository` so they also get the needed functionality.
+For all your custom repositories, extend them from the `ApiToolkitDefaultRepository` (or if you want them to be injectable, from `ApiToolkitRepository`, which extends from the `ServiceEntityRepository`, so be sure to implement the constructor the right way) so they also get the needed functionality.
 
 After that, add a `@ApiTK\Result` annotation to your controller action. The action parameter 
 will automatically gets filled with the filtered, sorted and paginated result set of the 

--- a/Repository/ApiToolkitDefaultRepository.php
+++ b/Repository/ApiToolkitDefaultRepository.php
@@ -3,18 +3,16 @@ declare(strict_types=1);
 
 namespace Shopping\ApiTKUrlBundle\Repository;
 
-use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\EntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
 use Shopping\ApiTKUrlBundle\Exception\PaginationException;
 use Shopping\ApiTKUrlBundle\Service\ApiService;
 
 /**
- * Class ApiToolkitRepository
+ * Class ApiToolkitDefaultRepository
  * @package Shopping\ApiTKUrlBundle\Repository
- *
- * @todo For 2.0.0, rename this to ApiToolkitServiceRepository and the other one to ApiToolkitRepository. Breaking change, but better naming...
  */
-class ApiToolkitRepository extends ServiceEntityRepository
+class ApiToolkitDefaultRepository extends EntityRepository
 {
 
     /**

--- a/Repository/ApiToolkitDefaultRepository.php
+++ b/Repository/ApiToolkitDefaultRepository.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Shopping\ApiTKUrlBundle\Repository;
 
-use Doctrine\Bundle\DoctrineBundle\Repository\EntityRepository;
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
 use Shopping\ApiTKUrlBundle\Exception\PaginationException;
 use Shopping\ApiTKUrlBundle\Service\ApiService;


### PR DESCRIPTION
When the current `ApiToolkitRepository` is used as the default_repository_class in the `doctrine.yaml`, you have to inject the entity's classname to alle repository services because of the way `ServiceEntityRepository` works.

I now added a `ApiToolkitDefaultRepository`, which only extends from `EntityRepository` and can be safely used as the default repository for doctrine. For alle, who need to make the Repository injectable, can extend their own repositories from the ServiceEntityRepository version (`ApiToolkitRepository`).

The naming should be changed in the next major version upgrade to reflect what is what.